### PR TITLE
Test: add isuruf to recipe-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,4 @@ extra:
   recipe-maintainers:
     - cshaley
     - sannykr
+    - isuruf


### PR DESCRIPTION
Can you merge this to test a new feature of `conda-forge-webservices` that adds maintainers to the github team instantly?

cc @jakirkham, @ocefpaf 